### PR TITLE
Laravel 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Metapackage for https://github.com/DivineOmega/laravel-password-exposed-validation-rule",
     "type": "metapackage",
     "require": {
-        "divineomega/laravel-password-exposed-validation-rule": "^2.1"
+        "divineomega/laravel-password-exposed-validation-rule": "^2.2"
     },
     "license": "LGPL-3.0-only"
 }


### PR DESCRIPTION
I think Composer will let us stick with the same version since the underlying package only did a minor release, but I updated the constraint anyway.